### PR TITLE
Support shadowDOM elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
 var matches = require('matches-selector')
+var types = 'HTMLDocument|ShadowRoot'
 
 module.exports = function (element, selector, checkYoSelf) {
   var parent = checkYoSelf ? element : element.parentNode
 
-  while (parent && parent !== document) {
+  while (parent && !parent.toString().match(types)) {
     if (matches(parent, selector)) return parent;
     parent = parent.parentNode
   }


### PR DESCRIPTION
`Closest` is being used by https://github.com/zenorocha/delegate which I am using in my project. Unfortunately `delegate` doesn't work for shadowDOM elements because of the strict checking `closest` is doing with the global `document` object.
