### PR TITLE
Update matches-selector dependency and mark as stable at 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "closest",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Find the closest parent that matches a selector.",
   "keywords": [
     "browserify",
@@ -11,7 +11,7 @@
     "jquery"
   ],
   "dependencies": {
-    "matches-selector": "0.0.1"
+    "matches-selector": "1.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Just noticed that my browserify build has two instances of [matches-selector](https://www.npmjs.com/package/matches-selector) since this module depends on `v0.0.1` and the current is `v1.0.0` so thought i'd make this PR to update the dependency.

Also I bumped the version to 1.0 since I assume this api is pretty stable after 4 years of no changes. but let me know if you want that reverted.
